### PR TITLE
Updating main.tf due to errors

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,11 +56,11 @@ resource "google_storage_bucket" "logging" {
   }
 
   lifecycle_rule {
-    "action" {
+    action {
       type = "Delete"
     }
 
-    "condition" {
+    condition {
       age = 60
     }
   }


### PR DESCRIPTION
I obtained this error executing terraform init:

```
$ terraform init
Initializing modules...
Downloading dansible/storage-bucket/google 1.1.0 for ...
-  .terraform/modules//dansible-terraform-google-storage-bucket-3c1edf1
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Invalid argument name

  on .terraform/modules/dansible-terraform-google-storage-bucket-3c1edf1/main.tf line 59, in resource "google_storage_bucket" "logging":
  59:     "action" {

Argument names must not be quoted.
```

My terraform client version is v0.12.10

```
$ terraform -v
Terraform v0.12.10
+ provider.google v2.17.0
+ provider.google-beta v2.17.0
```

Many thanks in advance